### PR TITLE
await missing

### DIFF
--- a/server/controllers/handleGetLeaderboard.js
+++ b/server/controllers/handleGetLeaderboard.js
@@ -51,7 +51,7 @@ export const handleGetLeaderboard = async (req, res) => {
     }
 
     if (shouldUpdateDataObject) {
-      world.updateDataObject({
+      await world.updateDataObject({
         [`keyAssets.${keyAssetId}.itemsCollectedByUser`]: itemsCollectedByUser,
       });
     }

--- a/server/controllers/handleUpdateAdminSettings.js
+++ b/server/controllers/handleUpdateAdminSettings.js
@@ -18,7 +18,10 @@ export const handleUpdateAdminSettings = async (req, res) => {
     });
 
     const lockId = `${assetId}-adminUpdates-${new Date(Math.round(new Date().getTime() / 10000) * 10000)}`;
-    droppedAsset.updateDataObject({ numberAllowedToCollect, questItemImage }, { lock: { lockId, releaseLock: true } });
+    await droppedAsset.updateDataObject(
+      { numberAllowedToCollect, questItemImage },
+      { lock: { lockId, releaseLock: true } },
+    );
 
     const droppedAssets = await getDroppedAssetsWithUniqueName({
       assetId,


### PR DESCRIPTION
I hope this fix solves this crash when public API is unavailable:

[https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/product[…]p%2F92537f0284554d6d8fcd8319172d239f](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/production-service-sdk-quest-prod-k12/log-events/sdk-quest-prod-k12%2Fsdk-quest-prod-k12-app%2F92537f0284554d6d8fcd8319172d239f)